### PR TITLE
(bug) Projects: separator line inside card is too thick

### DIFF
--- a/features/projects/components/project-card/project-card.module.scss
+++ b/features/projects/components/project-card/project-card.module.scss
@@ -19,7 +19,7 @@
 
 .bottomContainer {
   padding: space.$s4 space.$s6;
-  border-top: 3px solid color.$gray-200;
+  border-top: 1px solid color.$gray-200;
   display: flex;
   justify-content: flex-end;
 }


### PR DESCRIPTION
### What's Changing

Previous behavior was displaying the thickness of the divider at `3px` despite the Figma indicating that it should be at 1px. Fixed the `border-top` of the `.bottomContainer` to display the correct height.

style: changed thickness of ProjectCard divider
- The thickness of the separator line matches the designs

### Screenshots
<img width="1680" alt="Screenshot 2024-02-22 at 6 38 26 PM" src="https://github.com/profydev/prolog-app-heyoitsJuice/assets/42789583/4a35490a-9e4a-4056-a484-0c873b1faf3e">
