### PR TITLE
(bug) Issue List: Page info has the wrong color

### DIFF
--- a/features/issues/components/issue-list/issue-list.module.scss
+++ b/features/issues/components/issue-list/issue-list.module.scss
@@ -51,7 +51,7 @@
 }
 
 .pageInfo {
-  color: color.$gray-300;
+  color: color.$gray-700;
   font: font.$text-sm-regular;
 }
 


### PR DESCRIPTION
### What's Changing

Previous behavior was showing the page info in `gray-300`.  Changed it to `gray-700` to match Figma designs. 

style: fixed color of Pagination text to match designs
- The color of the page info matches the designs

### Screenshots
<img width="736" alt="Screenshot 2024-02-22 at 6 55 56 PM" src="https://github.com/profydev/prolog-app-heyoitsJuice/assets/42789583/8880b1a2-1dd1-4061-a8ff-93bb330cd780">
