### PR TITLE
(bug) Sidebar Navigation: Wrong logo when switching to mobile view

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -19,9 +19,9 @@
     @media (min-width: breakpoint.$desktop) {
       width: 5.1875rem;
 
-      .logo {
-        width: 1.4375rem;
-      }
+      // .logo {
+      //   width: 1.4375rem;
+      // }
     }
   }
 }
@@ -49,10 +49,31 @@
 }
 
 .logo {
-  width: 7.375rem;
+  @media (min-width: breakpoint.$desktop) {
+    margin: space.$s0 space.$s4;
+  }
+}
+
+.smallLogo {
+  width: 1.4375rem;
+  display: none;
 
   @media (min-width: breakpoint.$desktop) {
     margin: space.$s0 space.$s4;
+
+    &.isCollapsed {
+      display: block;
+    }
+  }
+}
+
+.largeLogo {
+  width: 7.375rem;
+
+  @media (min-width: breakpoint.$desktop) {
+    &.isCollapsed {
+      display: none;
+    }
   }
 }
 

--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -18,10 +18,6 @@
   &.isCollapsed {
     @media (min-width: breakpoint.$desktop) {
       width: 5.1875rem;
-
-      // .logo {
-      //   width: 1.4375rem;
-      // }
     }
   }
 }

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -20,6 +20,7 @@ export function SidebarNavigation() {
   const router = useRouter();
   const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+
   return (
     <div
       className={classNames(
@@ -36,14 +37,23 @@ export function SidebarNavigation() {
         <header className={styles.header}>
           {/* eslint-disable-next-line @next/next/no-img-element */}
           <img
-            src={
-              isSidebarCollapsed
-                ? "/icons/logo-small.svg"
-                : "/icons/logo-large.svg"
-            }
+            src={"/icons/logo-small.svg"}
             alt="logo"
-            className={styles.logo}
+            className={classNames(
+              styles.smallLogo,
+              isSidebarCollapsed && styles.isCollapsed,
+            )}
           />
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={"/icons/logo-large.svg"}
+            alt="logo"
+            className={classNames(
+              styles.largeLogo,
+              isSidebarCollapsed && styles.isCollapsed,
+            )}
+          />
+
           <Button
             onClick={() => setMobileMenuOpen(!isMobileMenuOpen)}
             className={styles.menuButton}


### PR DESCRIPTION
### What's Changing

The smaller logo was always showing when we switch orientations and toggle the sidebar nav. This would show a disproportionate logo. We end up creating two different style classes based on the media query (we use 1.4375rem and 7.375rem) and render the specific src logo (small, large) based on the style class.

fix: correctly show logo based on orientation and isCollapsed
- The header on mobile always shows the large logo.

### Screenshots

<img width="1055" alt="Screenshot 2024-03-04 at 3 27 09 PM" src="https://github.com/profydev/prolog-app-heyoitsJuice/assets/42789583/e04e87af-6d21-4390-85b3-970e45911e90">
<img width="1025" alt="Screenshot 2024-03-04 at 3 28 17 PM" src="https://github.com/profydev/prolog-app-heyoitsJuice/assets/42789583/c97500fa-db20-44cc-8eec-612f62d36c51">
<img width="578" alt="Screenshot 2024-03-04 at 3 28 34 PM" src="https://github.com/profydev/prolog-app-heyoitsJuice/assets/42789583/d3822fcb-56eb-4bc5-9043-c1a36d9a60b5">
