### PR TITLE
(bug): Sidebar Navigation: Support button should open the user’s mail app

### DIFF
--- a/cypress/e2e/navigation.cy.ts
+++ b/cypress/e2e/navigation.cy.ts
@@ -29,6 +29,14 @@ describe("Sidebar Navigation", () => {
       cy.get("nav")
         .contains("Settings")
         .should("have.attr", "href", "/dashboard/settings");
+
+      cy.get("nav")
+        .contains("Support")
+        .should(
+          "have.attr",
+          "href",
+          "mailto:support@prolog-app.com?subject=Support Request: ",
+        );
     });
 
     it("is collapsible", () => {
@@ -36,7 +44,7 @@ describe("Sidebar Navigation", () => {
       cy.get("nav").contains("Collapse").click();
 
       // check that links still exist and are functionable
-      cy.get("nav").find("a").should("have.length", 5).eq(1).click();
+      cy.get("nav").find("a").should("have.length", 6).eq(1).click();
       cy.url().should("eq", "http://localhost:3000/dashboard/issues");
 
       // check that text is not rendered
@@ -80,7 +88,7 @@ describe("Sidebar Navigation", () => {
       isInViewport("nav");
 
       // check that all links are rendered
-      cy.get("nav").find("a").should("have.length", 5);
+      cy.get("nav").find("a").should("have.length", 6);
 
       // Support button should be rendered but Collapse button not
       cy.get("nav").contains("Support").should("exist");

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -20,7 +20,6 @@ export function SidebarNavigation() {
   const router = useRouter();
   const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
-
   return (
     <div
       className={classNames(
@@ -89,14 +88,12 @@ export function SidebarNavigation() {
             ))}
           </ul>
           <ul className={styles.list}>
-            <MenuItemButton
+            <MenuItemLink
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() =>
-                (window.location.href =
-                  "mailto:support@prolog-app.com?subject=Support Request: ")
-              }
+              href="mailto:support@prolog-app.com?subject=Support Request: "
+              isActive={false}
             />
             <MenuItemButton
               text="Collapse"

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -93,7 +93,10 @@ export function SidebarNavigation() {
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              onClick={() =>
+                (window.location.href =
+                  "mailto:support@prolog-app.com?subject=Support Request: ")
+              }
             />
             <MenuItemButton
               text="Collapse"


### PR DESCRIPTION
### What's Changing

We were using an alert as a placeholder for the functionality of the `Support` button. Intended behavior is that when a user clicks the `Support` button they should be redirected to a mail app with the subject and recipient lines filled w/ the prolog info.

test: redirect support button to mail app
- The recipient should be “support@prolog-app.com”
- The subject line should be pre-filled with “Support Request: “
- Covered by a Cypress test

### Screenshots
<img width="1198" alt="Screenshot 2024-03-04 at 5 39 42 PM" src="https://github.com/profydev/prolog-app-heyoitsJuice/assets/42789583/3f73a65c-e39b-4f43-b737-0adf489c4e07">
